### PR TITLE
(write) preserve formatting and comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/miller-time/hq"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+hcl-edit = "0.8"
 hcl-rs = "0.17"
 pest = "2.7"
 pest_derive = "2.7"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ You can query the attribute(s) and block(s) in an HCL file like so:
 
 ```sh
 $ cat example.hcl | hq '.some_attr'
+```
+
+```hcl
 {
   foo = [
     1,
@@ -44,45 +47,75 @@ $ cat example.hcl | hq '.some_attr'
   ]
   bar = true
 }
+```
 
+```sh
 $ cat example.hcl | hq '.some_attr.foo'
+```
+
+```hcl
 [
   1,
   2
 ]
+```
 
+```sh
 $ cat example.hcl | hq '.some_block'
+```
+
+```hcl
 some_block "some_block_label" {
   attr = "value"
 }
 some_block "another_block_label" {
   attr = "another_value"
 }
+```
 
+```sh
 $ cat example.hcl | hq '.some_block[label="some_block_label"].attr'
-"value"
+```
 
+```hcl
+"value"
+```
+
+```sh
 $ cat example.hcl | hq '.some_block[label="another_block_label"].attr'
+```
+
+```hcl
 "another_value"
 ```
 
-You can modify HCL like so:
+You can modify HCL (even HCL that is formatted and contains comments) like so:
 
 ```sh
-$ cat example.hcl | hq '.some_block[label="some_block_label"].attr' write 'something_new'
+$ cat example.hcl | hq '.fmt_block.first_formatted_field' write '"something_new"'
+```
+
+```hcl
 some_attr = {
-  foo = [
-    1,
-    2
-  ]
-  bar = true
+    foo = [1, 2]
+    bar = true
 }
 
 some_block "some_block_label" {
-  attr = "something"
+    attr = "value"
 }
 
 some_block "another_block_label" {
-  attr = "another_value"
+    attr = "another_value"
+}
+
+# this is a block comment
+fmt_block "fmt_label" {
+    # this is a body comment
+    # this is another body comment
+
+    # this is a third body comment
+    first_formatted_field  = "something_new"
+    second_formatted_field = "second_value"
 }
 ```

--- a/example.hcl
+++ b/example.hcl
@@ -10,3 +10,13 @@ some_block "some_block_label" {
 some_block "another_block_label" {
     attr = "another_value"
 }
+
+# this is a block comment
+fmt_block "fmt_label" {
+    # this is a body comment
+    # this is another body comment
+
+    # this is a third body comment
+    first_formatted_field  = "fmt_value"
+    second_formatted_field = "second_value"
+}


### PR DESCRIPTION
using the hcl-edit visitor pattern (documented [here](https://docs.rs/hcl-edit/latest/hcl_edit/visit_mut/index.html)), we can traverse the HCL document and perform edits on nodes that carry formatting and comment "decoration"