### PR TITLE
ryanpham/delete/nested object

### DIFF
--- a/tests/delete-tests.rs
+++ b/tests/delete-tests.rs
@@ -83,3 +83,16 @@ fn delete_from_object() -> Result<(), Box<dyn Error>> {
     assert_eq!("local { obj = {} }", body.to_string());
     Ok(())
 }
+
+#[test]
+fn delete_from_nested_object() -> Result<(), Box<dyn Error>> {
+    // filter '.local.obj.obj2.val'
+    let fields = vec![Field::new("local"), Field::new("obj"), Field::new("obj2"), Field::new("val")];
+
+    let mut body = utilities::edit_hcl("local { obj = { obj2 = { val = 5 } } }")?;
+
+    delete(fields, &mut body)?;
+
+    assert_eq!("local { obj = { obj2 = {} } }", body.to_string());
+    Ok(())
+}


### PR DESCRIPTION
- **delete: refactor iteration**
  This refactors the implementation of `HclDeleter` to make it
  non-destructive. This is important for if / when wildcards are supported
  as we'll need to backtrack through the fields if the wildcard is not
  placed as the final part in the query.
  

- **delete: handle nested objects**
  