### PR TITLE
delete: handle nested objects

### DIFF
--- a/src/delete.rs
+++ b/src/delete.rs
@@ -12,7 +12,7 @@ use crate::parser::Field;
 struct HclDeleter {
     fields: Vec<Field>,
     current_index: usize,
-    next: Option<Field>,
+    current: Option<Field>,
     error: Option<Box<dyn Error>>,
 }
 
@@ -22,18 +22,19 @@ impl HclDeleter {
         HclDeleter {
             fields,
             current_index: 0,
-            next: next,
+            current: next,
             error: None,
         }
     }
 
     fn next_field(&mut self) {
         self.current_index += 1;
-        self.next = self.fields.get(self.current_index).cloned();
+        self.current = self.fields.get(self.current_index).cloned();
     }
 
     fn previous_field(&mut self) {
         self.current_index -= 1;
+        self.current = self.fields.get(self.current_index).cloned();
     }
 
     fn should_remove(&self) -> bool {
@@ -44,21 +45,20 @@ impl HclDeleter {
 impl VisitMut for HclDeleter {
     fn visit_body_mut(&mut self, node: &mut Body) {
         let should_remove = self.should_remove();
-        if let Some(ref next) = self.next.clone() {
-            self.next_field();
+        if let Some(ref curr) = self.current.clone() {
             for (index, item) in node.clone().iter().enumerate() {
                 match item {
                     Structure::Attribute(attr) => {
-                        if attr.key.as_str() == next.name && should_remove {
+                        if attr.key.as_str() == curr.name && should_remove {
                             node.remove_attribute(attr.key.as_str());
                         }
                     }
                     Structure::Block(block) => {
-                        if block.ident.as_str() == next.name && should_remove {
-                            if next.labels.is_empty() {
+                        if block.ident.as_str() == curr.name && should_remove {
+                            if curr.labels.is_empty() {
                                 node.remove(index);
                             } else {
-                                for filter_label in &next.labels {
+                                for filter_label in &curr.labels {
                                     for block_label in &block.labels {
                                         if block_label.as_str() == filter_label {
                                             node.remove_blocks(block.ident.as_str());
@@ -74,18 +74,21 @@ impl VisitMut for HclDeleter {
             // check again for matches, these indicate that there are additional filter segments
             // (because if there was a match above, then the matching item is already gone)
             for attr in node.attributes_mut() {
-                if attr.key.as_str() == next.name {
+                self.next_field();
+                if attr.key.as_str() == curr.name {
                     self.visit_attr_mut(attr);
                 }
+                self.previous_field();
             }
 
             for block in node.blocks_mut() {
-                if block.ident.as_str() == next.name {
-                    if next.labels.is_empty() {
+                self.next_field();
+                if block.ident.as_str() == curr.name {
+                    if curr.labels.is_empty() {
                         // then visit the body
                         self.visit_body_mut(&mut block.body);
                     } else {
-                        for filter_label in &next.labels {
+                        for filter_label in &curr.labels {
                             for block_label in &block.labels {
                                 if block_label.as_str() == filter_label {
                                     // then visit the body
@@ -95,38 +98,47 @@ impl VisitMut for HclDeleter {
                         }
                     }
                 }
+                self.previous_field();
             }
         }
-
-        self.previous_field();
     }
 
     fn visit_object_mut(&mut self, node: &mut hcl_edit::expr::Object) {
-        if let Some(ref next) = self.next.clone() {
-            self.next_field();
+        if let Some(ref curr) = self.current.clone() {
             let mut matches = Vec::new();
             for (key, _) in node.iter() {
                 // some objects are keyed with an Ident
                 if let Some(id) = key.as_ident() {
-                    if id.as_str() == next.name {
+                    if id.as_str() == curr.name {
                         matches.push(key.clone());
                     }
                 }
                 // some objects are keyed with a String Expression
                 if let Some(expr) = key.as_expr() {
                     if let Some(expr) = expr.as_str() {
-                        if expr == next.name {
+                        if expr == curr.name {
                             matches.push(key.clone());
                         }
                     }
                 }
             }
+
             for key in matches {
-                node.remove(&key);
+                if self.should_remove() {
+                    node.remove(&key);
+                } else if let Some(val) = node.get_mut(&key) {
+                    // If we haven't reached the end of the query, we need to traverse further into
+                    // the AST to determine what needs to be deleted.
+                    self.next_field();
+                    self.visit_object_value_mut(val);
+                    self.previous_field();
+                } else {
+                    // Every key in this vec was gotten by iterating over this object, so the value
+                    // should exist and this branch should not be reachable.
+                    unreachable!();
+                }
             }
         }
-
-        self.previous_field();
     }
 }
 

--- a/tests/delete-tests.rs
+++ b/tests/delete-tests.rs
@@ -83,3 +83,16 @@ fn delete_from_object() -> Result<(), Box<dyn Error>> {
     assert_eq!("local { obj = {} }", body.to_string());
     Ok(())
 }
+
+#[test]
+fn delete_from_nested_object() -> Result<(), Box<dyn Error>> {
+    // filter '.local.obj.obj2.val'
+    let fields = vec![Field::new("local"), Field::new("obj"), Field::new("obj2"), Field::new("val")];
+
+    let mut body = utilities::edit_hcl("local { obj = { obj2 = { val = 5 } } }")?;
+
+    delete(fields, &mut body)?;
+
+    assert_eq!("local { obj = { obj2 = {} } }", body.to_string());
+    Ok(())
+}


### PR DESCRIPTION
- **delete: refactor iteration**
  This refactors the implementation of `HclDeleter` to make it
  non-destructive. This is important for if / when wildcards are supported
  as we'll need to backtrack through the fields if the wildcard is not
  placed as the final part in the query.
  

- **delete: handle nested objects**
  This handles deletion from nested objects. Given the following terraform
  file
  
  ```hcl
  local {
    obj = {
      obj2 = {
        val = 5
      }
    }
  }
  ```
  
  and the following delete query, `hq delete .local.obj.obj2.val`, the
  previous behavior outputs:
  
  ```hcl
  local {
    obj = {}
  }
  ```
  
  The new behavior outputs:
  ```hcl
  local {
    obj = {
      obj2 = {}
    }
  }
  ```
  