### PR TITLE
grammar: disable fields starting with labels

### DIFF
--- a/src/filter/grammar.pest
+++ b/src/filter/grammar.pest
@@ -1,5 +1,5 @@
 filter      = _{ SOI ~ field ~ (field)* ~ EOI }
-field       =  { (index | prop) ~ labels? }
+field       =  { prop ~ labels? }
 index       = _{ "[" ~ quote ~ quoted_name ~ quote ~ "]" }
 quote       = _{ "\"" | "'" }
 quoted_name =  { quoted_char+ }


### PR DESCRIPTION
As discussed here[^1], fields should not be able to start with labels.
Fields should specifically start with a prop which is optionally
followed by a label.

[^1]: https://github.com/miller-time/hq/pull/24#discussion_r1959122862
