### PR TITLE
write - insert new attr

### DIFF
--- a/src/bin/hq.rs
+++ b/src/bin/hq.rs
@@ -178,7 +178,7 @@ fn write(file: Option<String>, inline: bool, expr: String) -> Result<(), Box<dyn
     let new_value = parts[1];
     let expr: hcl_edit::expr::Expression = new_value.parse()?;
     let fields = hq_rs::parse_filter(filter)?;
-    hq_rs::write(fields, &mut body, &expr)?;
+    hq_rs::write(fields, &mut body, &expr);
 
     if inline {
         // When inline is set, write the modified HCL back to the file

--- a/src/write.rs
+++ b/src/write.rs
@@ -2,8 +2,9 @@
 
 use hcl_edit::{
     expr::Expression,
-    structure::{Body, Structure},
+    structure::{Attribute, Body, Structure},
     visit_mut::VisitMut,
+    Decorated, Ident,
 };
 
 use crate::parser::Field;
@@ -87,6 +88,12 @@ impl VisitMut for HclEditor<'_> {
                     self.visit_body_mut(&mut block.body);
                     self.previous_field();
                 }
+            }
+
+            if self.should_edit() {
+                let key = Decorated::new(Ident::new(current.name));
+                let attr = Attribute::new(key, self.value.clone());
+                node.insert(node.len(), attr);
             }
         }
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,7 +1,5 @@
 //! use the [`hcl-edit`][hcl_edit] crate to modify HCL documents
 
-use std::{error::Error, fmt};
-
 use hcl_edit::{
     expr::Expression,
     structure::{Body, Structure},
@@ -10,37 +8,11 @@ use hcl_edit::{
 
 use crate::parser::Field;
 
-#[derive(Debug)]
-pub struct WriteError {
-    reason: String,
-}
-
-impl WriteError {
-    fn new(reason: &str) -> Self {
-        WriteError {
-            reason: reason.to_string(),
-        }
-    }
-}
-
-impl fmt::Display for WriteError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "failed to write HCL: {}", self.reason)
-    }
-}
-
-impl Error for WriteError {}
-
-fn err(reason: &str) -> Box<WriteError> {
-    Box::new(WriteError::new(reason))
-}
-
 struct HclEditor<'a> {
     fields: Vec<Field>,
     current_index: usize,
     current: Option<Field>,
     value: &'a Expression,
-    error: Option<Box<WriteError>>,
 }
 
 impl<'a> HclEditor<'a> {
@@ -51,7 +23,6 @@ impl<'a> HclEditor<'a> {
             current_index: 0,
             current,
             value,
-            error: None,
         }
     }
 
@@ -134,15 +105,7 @@ impl VisitMut for HclEditor<'_> {
 
 /// given a vector of [`Field`]s, write `value` to replace the existing
 /// [`Expression`] that matches that filter
-pub fn write(
-    fields: Vec<Field>,
-    body: &mut Body,
-    value: &Expression,
-) -> Result<(), Box<WriteError>> {
+pub fn write(fields: Vec<Field>, body: &mut Body, value: &Expression) {
     let mut visitor = HclEditor::new(fields, value);
     visitor.visit_body_mut(body);
-    if let Some(err) = visitor.error {
-        return Err(err);
-    }
-    Ok(())
 }

--- a/tests/write-tests.rs
+++ b/tests/write-tests.rs
@@ -9,7 +9,7 @@ fn attr() {
 
     let value: hcl_edit::expr::Expression = "\"new_value\"".parse().expect("parse error");
 
-    write(fields, &mut body, &value).expect("write error");
+    write(fields, &mut body, &value);
 
     assert_eq!("version = \"new_value\"", body.to_string());
 }
@@ -23,7 +23,7 @@ fn block_attr() {
 
     let value: hcl_edit::expr::Expression = "true".parse().expect("parse error");
 
-    write(fields, &mut body, &value).expect("write error");
+    write(fields, &mut body, &value);
 
     assert_eq!("options { enabled = true }", body.to_string());
 }
@@ -41,7 +41,7 @@ fn labeled_block_attr() {
 
     let value: hcl_edit::expr::Expression = "\"2.0\"".parse().expect("parse error");
 
-    write(fields, &mut body, &value).expect("write error");
+    write(fields, &mut body, &value);
 
     assert_eq!(
         "module \"cool-module\" { version = \"2.0\" }",

--- a/tests/write-tests.rs
+++ b/tests/write-tests.rs
@@ -61,7 +61,7 @@ fn insert() {
     write(fields, &mut body, &value);
 
     assert_eq!(
-        "options {\n attr = \"value\" \nnew_attr = \"new_value\"\n}",
+        "options {\n attr = \"value\" \n new_attr = \"new_value\" \n}",
         body.to_string()
     );
 }

--- a/tests/write-tests.rs
+++ b/tests/write-tests.rs
@@ -48,3 +48,20 @@ fn labeled_block_attr() {
         body.to_string()
     );
 }
+
+#[test]
+fn insert() {
+    // filter '.options.new_attr'
+    let fields = vec![Field::new("options"), Field::new("new_attr")];
+
+    let mut body = utilities::edit_hcl("options { attr = \"value\" }").expect("hcl error");
+
+    let value: hcl_edit::expr::Expression = "\"new_value\"".parse().expect("parse error");
+
+    write(fields, &mut body, &value);
+
+    assert_eq!(
+        "options {\n attr = \"value\" \nnew_attr = \"new_value\"\n}",
+        body.to_string()
+    );
+}


### PR DESCRIPTION
given some simple HCL:

```hcl
props {
  version = "0.0.1"
}
```

**before:**

if the expression didn't correspond to an existing path in the HCL, the edit was a no-op:

```txt
hq write '.props.edition="alpha"'

props {
  version = "0.0.1"
}
```

**now:**

```txt
hq write '.props.edition="alpha"'

props {
  version = "0.0.1"
  edition = "alpha"
}
```
